### PR TITLE
Bump release version to 0.2.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject singer-clojure "0.1.0"
+(defproject singer-clojure "0.2.0"
   :description "Clojure library for shared code between clojure taps"
   :url "https://github.com/singer-io/singer-clojure"
   :license {:name "GNU General Public License Version 3; Other commercial licenses available."


### PR DESCRIPTION
# Description of change
Bump release version to 0.2.0 - https://stitchdata.atlassian.net/browse/SRCE-2785

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
