### PR TITLE
Bump version to 1.0.0 for the license fix

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject singer-clojure "0.2.0"
+(defproject singer-clojure "1.0.0"
   :description "Clojure library for shared code between clojure taps"
   :url "https://github.com/singer-io/singer-clojure"
   :license {:name "GNU Affero General Public License Version 3; Other commercial licenses available."


### PR DESCRIPTION
# Description of change
Bump version to 1.0.0 for the license fix

Also we said after we validated it working with tap-netsuite we would release a 1.0.0 version and we never did

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
