### PR TITLE
Feature: currently_syncing

### DIFF
--- a/src/singer_clojure/catalog.clj
+++ b/src/singer_clojure/catalog.clj
@@ -1,11 +1,22 @@
 (ns singer-clojure.catalog
   (:require [clojure.test :refer [is]]))
 
+(defn- shuffle-streams
+  "Shuffle streams to place `currently_syncing` at the front. If currently_syncing does not exist, start over."
+  [selected-streams state]
+  (let [currently-syncing (:currently_syncing state)
+        front (take-while #(not= currently-syncing %) selected-streams)
+        back (drop-while #(not= currently-syncing %) selected-streams)]
+    (concat back front)))
+
 (defn get-selected-streams
-  [catalog]
   "Takes a deserialized catalog and returns a sequence of the selected
   tap-stream-ids"
-  (filter #(get-in catalog [% "metadata" "selected"]) (keys catalog)))
+  ([catalog]
+   (get-selected-streams catalog {}))
+  ([catalog state]
+   (-> (filter #(get-in catalog [% "metadata" "selected"]) (keys catalog))
+       (shuffle-streams state))))
 
 
 (defn- serialize-stream-metadata-property

--- a/src/singer_clojure/catalog.clj
+++ b/src/singer_clojure/catalog.clj
@@ -1,10 +1,11 @@
 (ns singer-clojure.catalog
-  (:require [clojure.test :refer [is]]))
+  (:require [singer-clojure.bookmarks :as bookmarks]
+            [clojure.test :refer [is]]))
 
 (defn- shuffle-streams
   "Shuffle streams to place `currently_syncing` at the front. If currently_syncing does not exist, start over."
   [selected-streams state]
-  (let [currently-syncing (get state "currently_syncing")
+  (let [currently-syncing (bookmarks/get-currently-syncing state)
         front (take-while #(not= currently-syncing %) selected-streams)
         back (drop-while #(not= currently-syncing %) selected-streams)]
     (concat back front)))

--- a/src/singer_clojure/catalog.clj
+++ b/src/singer_clojure/catalog.clj
@@ -4,7 +4,7 @@
 (defn- shuffle-streams
   "Shuffle streams to place `currently_syncing` at the front. If currently_syncing does not exist, start over."
   [selected-streams state]
-  (let [currently-syncing (:currently_syncing state)
+  (let [currently-syncing (get state "currently_syncing")
         front (take-while #(not= currently-syncing %) selected-streams)
         back (drop-while #(not= currently-syncing %) selected-streams)]
     (concat back front)))

--- a/test/singer_clojure/catalog_test.clj
+++ b/test/singer_clojure/catalog_test.clj
@@ -31,7 +31,7 @@
                                "metadata"      {"selected" false}}
                    "stream_e" { "stream"       "stream_e"
                                "metadata"      {"selected" true}}}
-          state {:currently_syncing "stream_c"}]
+          state {"currently_syncing" "stream_c"}]
       (is (= (get-selected-streams catalog state)
              '("stream_c" "stream_e" "stream_a"))))))
 
@@ -48,7 +48,7 @@
                                "metadata"      {"selected" false}}
                    "stream_e" { "stream"       "stream_e"
                                "metadata"      {"selected" true}}}
-          state {:currently_syncing "stream_b"}]
+          state {"currently_syncing" "stream_b"}]
       (is (= (get-selected-streams catalog state)
              '("stream_a" "stream_c" "stream_e"))))))
 
@@ -65,7 +65,7 @@
                                "metadata"      {"selected" false}}
                    "stream_e" { "stream"       "stream_e"
                                "metadata"      {"selected" true}}}
-          state {:currently_syncing "stream_x"}]
+          state {"currently_syncing" "stream_x"}]
       (is (= (get-selected-streams catalog state)
              '("stream_a" "stream_c" "stream_e"))))))
 

--- a/test/singer_clojure/catalog_test.clj
+++ b/test/singer_clojure/catalog_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer :all]
             [singer-clojure.catalog :refer :all]))
 
-(deftest get-selected-streams-test
+(deftest get-selected-streams-respects-selected-metadata
   (testing "Test that the get-selected-stream properly returns a sequence
   of selected streams"
     (let [catalog {"stream_a" { "stream"       "stream_a"
@@ -16,6 +16,57 @@
                    "stream_e" { "stream"       "stream_e"
                                "metadata"      {"selected" true}}}]
       (is (= (get-selected-streams catalog)
+             '("stream_a" "stream_c" "stream_e"))))))
+
+(deftest get-selected-streams-with-currently-syncing-shuffles
+  (testing "Test that the get-selected-stream properly returns a sequence
+  of selected streams, shuffled to respect `currently_syncing` in state"
+    (let [catalog {"stream_a" { "stream"       "stream_a"
+                               "metadata"      {"selected" true}}
+                   "stream_b" { "stream"       "stream_b"
+                               "metadata"      {"selected" false}}
+                   "stream_c" { "stream"       "stream_c"
+                               "metadata"      {"selected" true}}
+                   "stream_d" { "stream"       "stream_d"
+                               "metadata"      {"selected" false}}
+                   "stream_e" { "stream"       "stream_e"
+                               "metadata"      {"selected" true}}}
+          state {:currently_syncing "stream_c"}]
+      (is (= (get-selected-streams catalog state)
+             '("stream_c" "stream_e" "stream_a"))))))
+
+(deftest get-selected-streams-with-currently-syncing-deselected-does-not-shuffle
+  (testing "Test that the get-selected-stream properly returns a sequence
+  of selected streams, unshuffled, if `currently_syncing` is deselected."
+    (let [catalog {"stream_a" { "stream"       "stream_a"
+                               "metadata"      {"selected" true}}
+                   "stream_b" { "stream"       "stream_b"
+                               "metadata"      {"selected" false}}
+                   "stream_c" { "stream"       "stream_c"
+                               "metadata"      {"selected" true}}
+                   "stream_d" { "stream"       "stream_d"
+                               "metadata"      {"selected" false}}
+                   "stream_e" { "stream"       "stream_e"
+                               "metadata"      {"selected" true}}}
+          state {:currently_syncing "stream_b"}]
+      (is (= (get-selected-streams catalog state)
+             '("stream_a" "stream_c" "stream_e"))))))
+
+(deftest get-selected-streams-with-currently-syncing-missing-does-not-shuffle
+  (testing "Test that the get-selected-stream properly returns a sequence
+  of selected streams, unshuffled, if `currently_syncing` is missing."
+    (let [catalog {"stream_a" { "stream"       "stream_a"
+                               "metadata"      {"selected" true}}
+                   "stream_b" { "stream"       "stream_b"
+                               "metadata"      {"selected" false}}
+                   "stream_c" { "stream"       "stream_c"
+                               "metadata"      {"selected" true}}
+                   "stream_d" { "stream"       "stream_d"
+                               "metadata"      {"selected" false}}
+                   "stream_e" { "stream"       "stream_e"
+                               "metadata"      {"selected" true}}}
+          state {:currently_syncing "stream_x"}]
+      (is (= (get-selected-streams catalog state)
              '("stream_a" "stream_c" "stream_e"))))))
 
 ;; `serialized-test-catalog` and `deserialized-test-catalog` are def'd


### PR DESCRIPTION
# Description of change
Adds `currently_syncing` option to `get-selected-streams`, if the key is contained in the state. Expands tests to cover some common cases for this feature. This is accomplished with a new arity for `get-selected-streams` to maintain backwards compatibility and provide this feature as an option.

NOTE: The implementation here is explicitly designated to NOT shuffle the streams in the case that a bookmarked stream has been deselected or no longer exists in the catalog. In these cases, syncing will begin from the first stream.

# Manual QA steps
 - None, tested using REPL and unit tests
 
# Risks
 - Low, the previous API has been maintained.
 
# Rollback steps
 - revert this branch and bump patch version of library
