### PR TITLE
Add fatal logging

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,6 +3,7 @@
   :url "https://github.com/singer-io/singer-clojure"
   :license {:name "GNU Affero General Public License Version 3; Other commercial licenses available."
             :url "https://www.gnu.org/licenses/agpl-3.0.en.html"}
+  :resource-paths ["resources/base"]
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.clojure/data.json "0.2.6"]
 

--- a/resources/base/log4j.properties
+++ b/resources/base/log4j.properties
@@ -1,0 +1,29 @@
+#
+# Loader Delta logging.
+#
+# See
+#
+# https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/PatternLayout.html
+# and http://www.kdgregory.com/index.php?page=java.logging
+#
+# for information on how to build ConversionPatterns
+log4j.rootLogger=INFO, CONSOLE
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.CONSOLE.Target=System.err
+log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %-5p [%t] %c - %m%n
+
+log4j.logger.singer-clojure.log=ERROR, CRITICALLINES
+log4j.appender.CRITICALLINES=org.apache.log4j.ConsoleAppender
+log4j.appender.CRITICALLINES.Target=System.err
+log4j.appender.CRITICALLINES.layout=org.apache.log4j.PatternLayout
+log4j.appender.CRITICALLINES.layout.ConversionPattern=FATAL %d{ISO8601} [%t] %m%n
+log4j.additivity.singer-clojure.log=false
+
+# log4j.logger.com.stitchdata.target-stitch-avro.flush-pipeline=ERROR, CRITICALLINES
+# log4j.appender.CRITICALLINES=org.apache.log4j.ConsoleAppender
+# log4j.appender.CRITICALLINES.Target=System.err
+# log4j.appender.CRITICALLINES.layout=org.apache.log4j.PatternLayout
+# log4j.appender.CRITICALLINES.layout.ConversionPattern=FATAL %d{ISO8601} %-5p [%t] %c - %m%n
+# log4j.additivity.com.stitchdata.target-stitch-avro.flush-pipeline=false
+# log4j.logger.com.stitchdata.target-stitch-avro.flush-pipeline=INFO, CONSOLE

--- a/src/singer_clojure/log.clj
+++ b/src/singer_clojure/log.clj
@@ -1,0 +1,21 @@
+(ns singer-clojure.log
+  (:require
+   [clojure.string :as clj-str]
+   [clojure.tools.logging :as log]))
+
+(defn compile-message [calling-ns msg ex]
+  (if ex
+    (str calling-ns " - " msg " : " (.getMessage ex) "\n")
+    (str calling-ns " - " msg "\n")))
+
+(defn fatal
+  ([msg calling-ns]
+   (log/error (compile-message calling-ns msg nil) ))
+  ([msg calling-ns ex]
+   (log/error (compile-message calling-ns msg ex) ex )))
+
+(defmacro log-fatal
+  ([msg]
+   `(fatal ~msg ~*ns*))
+  ([msg ex]
+   `(fatal ~msg ~*ns* ~ex)))


### PR DESCRIPTION
# Description of change
Adds a `log` namespace containing a `log-fatal` macro.

Can be called to log a message `<log_message>` with an optional exception `<exception>` input in the form:
```
FATAL <timestamp> <thread> <namespace> - <log_message> : <exception_message>
```
e.g.
```
FATAL 2020-12-17 16:38:55,130 [main] com.stitchdata.tap-rando.main - Caught a fatal error : An exception message
```

This also adds a `log4j.properties` file that will set up logging for any applications using this library.  

NOTE: If a tap uses this library and has a `log4j.properties` file, it will override singer-clojure's `log4j.properties`, so **taps using this library should NOT include a `log4j.properties`**

### Background
Since [SLF4J does not support Fatal error messages](http://www.slf4j.org/faq.html#fatal) and the orchestrator looks for `FATAL` or `CRITICAL` prefixes when deciding what to use as a tap/target error description, we needed a way to prepend `FATAL` when logging fatal messages. We cannot assume that libraries aren't using SLF4J, so simply removing the SLF4J dependency isn't feasible. 

Instead of adding an additional prefix to the orchestrator's critical prefixes list, we chose this approach since it provides flexibility if we ever want to do more than just log the critical message.

This new singer-clojure function will be used by both the tap and the target since exceptions thrown in threads do not propagate to the main thread, so the target threads need a way to log fatal messages before calling `(system/exit)`

# Manual QA steps
 - Tested with tap, target, and orchestrator
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
