### PR TITLE
default exception message to empty string

### DIFF
--- a/src/singer_clojure/log.clj
+++ b/src/singer_clojure/log.clj
@@ -8,7 +8,7 @@
   ([msg calling-ns]
    (log/error (str calling-ns " - " msg)))
   ([msg calling-ns ex]
-   (doseq [next-msg  (string/split (.getMessage ^Exception ex) #"\n")]
+   (doseq [next-msg  (string/split (or (.getMessage ^Exception ex) "") #"\n")]
      (log/error (str calling-ns " - " msg " - " next-msg)))
    (log/error ex)))
 


### PR DESCRIPTION
# Description of change
default exception message to empty string

# Manual QA steps
 -  Ran code
 
# Risks
 - None
 
# Rollback steps
 - revert this branch
