### PR TITLE
Sort streams before shuffling

### DIFF
--- a/src/singer_clojure/catalog.clj
+++ b/src/singer_clojure/catalog.clj
@@ -17,8 +17,8 @@
    (get-selected-streams catalog {}))
   ([catalog state]
    (-> (filter #(get-in catalog [% "metadata" "selected"]) (keys catalog))
+       sort
        (shuffle-streams state))))
-
 
 (defn- serialize-stream-metadata-property
   [[stream-metadata-property-name stream-metadata-property-metadata :as stream-metadata-property]]


### PR DESCRIPTION
# Description of change
Sort the streams before shuffling the currently syncing to the front to enforce a consistent ordering of streams. This allows the taps to properly continue from where they left off after being interrupted.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
